### PR TITLE
Fix compile error on gcc 7.x (int vs size_t comparison)

### DIFF
--- a/src/parodus_interface.c
+++ b/src/parodus_interface.c
@@ -223,7 +223,7 @@ bool hub_send_msg(const char *url, const void *notification, size_t notification
     sleep(2);
     do {
         bytes_sent = nn_send(sock, notification, notification_size, NN_DONTWAIT);
-    } while( bytes_sent != notification_size );// nn_send always returning errno as EAGAIN even in success case
+    } while( bytes_sent != (int ) notification_size );// nn_send always returning errno as EAGAIN even in success case
     if( bytes_sent < 0 ) {
         ParodusError("Hub send msg - bytes_sent = %d, %d(%s)\n", bytes_sent, errno, strerror(errno));
         goto finished;


### PR DESCRIPTION
Will be adding some more to this PR later on, i.e. ability to start a program (executable) via a command line argument for a local config file, i.e. which network interface to use varies on different machines. 