### PR TITLE
Fix for hub_check_inbox func and propagate the spoke incoming message to its local registered printer

### DIFF
--- a/src/parodus_interface.c
+++ b/src/parodus_interface.c
@@ -159,10 +159,8 @@ ssize_t hub_check_inbox(void **notification)
         if( msg_sz < 0 && EAGAIN != errno ) {
             ParodusError("Hub parodus receive error %d, %d(%s)\n", msg_sz, errno, strerror(errno));
             return -1;
-        } else {
-            break;
-        }
-    } while( EAGAIN == errno );
+        } 
+    } while( msg_sz < 0 );
 
     if( msg_sz > 0 ) {
         *notification = malloc(msg_sz);

--- a/src/peer2peer.c
+++ b/src/peer2peer.c
@@ -115,7 +115,11 @@ void *process_P2P_IncomingMessage()
 		                ParodusError("Failed to send event to spoke\n");
 		            }
 			}
-			else if (0 == strncmp("spk", get_parodus_cfg()->hub_or_spk, 3) )
+			//Send event to all registered clients for both hub and spoke incoming msg 
+			sendToAllRegisteredClients(&message->msg, message->len);
+			
+			
+			/*else if (0 == strncmp("spk", get_parodus_cfg()->hub_or_spk, 3) )
                         {
                             status = spoke_send_msg(SPK1_URL, message->msg, message->len);
                             if(status == true)
@@ -132,7 +136,7 @@ void *process_P2P_IncomingMessage()
 				// For incoming of type spoke, use sendToAllRegisteredClients() to propagate message to its local registered printer. 
                                 // If source is itself then ignore the message
 				sendToAllRegisteredClients(&message->msg, message->len);
-			}
+			}*/
                 /*}
             }
             else


### PR DESCRIPTION
Please correct me if I'm wrong, With this commit https://github.com/schmidtw/parodus/commit/65c75d4b15e92d462897bc7a22ffd5ec4eb0e2e0 incoming message from hub to spoke will not propagate the message to its local registered printer, instead it will reply the same event message again to the hub (which is not required, so reverted this commit).

Also as per my understanding, we need to propagate the incoming event message to all the registered client for both hub as well as spoke, I added changes to handle this case. Please review and comment in case if any changes are required.