### PR TITLE
Adding the skeleton for parsing configuration json file, with some of…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SOURCES main.c mutex.c networking.c nopoll_helpers.c nopoll_handlers.c
     ParodusInternal.c string_helpers.c time.c config.c conn_interface.c
     connection.c spin_thread.c client_list.c service_alive.c
     upstream.c downstream.c thread_tasks.c partners_check.c token.c
-    parodus_interface.c peer2peer.c)
+    parodus_interface.c peer2peer.c config_file.c )
 
 if (ENABLE_SESHAT)
 set(SOURCES ${SOURCES} seshat_interface.c)

--- a/src/config.c
+++ b/src/config.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <fcntl.h> 
 #include "config.h"
+#include "config_file.h"
 #include "ParodusInternal.h"
 #include <cjwt/cjwt.h>
 
@@ -269,6 +270,8 @@ unsigned int parse_num_arg (const char *arg, const char *arg_name)
 
 int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 {
+    bool keepParsing = true;
+    
     static const struct option long_options[] = {
         {"hw-model",                required_argument, 0, 'm'},
         {"hw-serial-number",        required_argument, 0, 's'},
@@ -297,9 +300,11 @@ int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 	{"token-acquisition-script",     required_argument, 0, 'J'},
         {"hub-or-spoke",            required_argument, 0, 'h'},
         {"Xmidt", no_argument, 0, 'X'}, /* Parodus MUST not try to connect to Xmidt */
+        /* Overrides all other arguments, will parse the configuration file specified */
+        {"config-file", required_argument, 0, 'F'}, 
         {0, 0, 0, 0}
     };
-    const char *option_string = "X::m:s:f:d:r:n:b:u:t:o:i:l:p:e:D:j:a:k:c:T:J:46:h";
+    const char *option_string = "F:X::m:s:f:d:r:n:b:u:t:o:i:l:p:e:D:j:a:k:c:T:J:46:h";
     int c;
     ParodusInfo("Parsing parodus command line arguments..\n");
 
@@ -313,7 +318,7 @@ int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 	cfg->jwt_algo = 0;
 	parStrncpy (cfg->jwt_key, "", sizeof(cfg->jwt_key));
 	optind = 1;  /* We need this if parseCommandLine is called again */
-    while (1)
+    while (keepParsing)
     {
 
       /* getopt_long stores the option index here. */
@@ -475,6 +480,18 @@ int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 parseCommandLine(): Xmidt is overriden ;-), will skip connection!\n");
               connectToXmidt = false;
               break;
+              
+          case 'F':
+              if (optarg) {
+                ParodusInfo("file name for configuration %s\n", optarg);
+                if (0 == processParodusCfg(cfg, optarg)) {
+                  keepParsing = false; // This overwrites all others! 
+                }
+              } else {
+                  ParodusError("Missing configuration file name with -F option!\n");
+              }
+              break;
+              
         default:
            ParodusError("Enter Valid commands..\n");
 		   return -1;

--- a/src/config.h
+++ b/src/config.h
@@ -52,12 +52,26 @@ extern "C" {
 #define PARTNER_ID              "partner-id"
 #define CERT_PATH               "ssl-cert-path"
 
-#define PROTOCOL_VALUE 					"PARODUS-2.0"
-#define WEBPA_PATH_URL                  "/api/v2/device"
-#define JWT_ALGORITHM					"jwt-algo"
-#define	JWT_KEY						"jwt-key"
-#define DNS_TXT_URL	"fabric"
-#define PARODUS_UPSTREAM                "tcp://127.0.0.1:6666"
+/* Flying Circus Possible Additions */
+typedef enum {
+    INVALID_TYPE = 0,
+    HUB = 1,
+    SPOKE = 2  
+} instance_type_t;
+
+#define INSTANCE_TYPE           "instance-type" /* instance_type_t */
+#define INSTANCE_URL            "instance-url" /* URL of a spoke ? */
+/* Used only in debugging */
+#define ALIVE_TIME              "life-time"
+/* End Flying Circus */    
+
+
+#define PROTOCOL_VALUE 		 "PARODUS-2.0"
+#define WEBPA_PATH_URL           "/api/v2/device"
+#define JWT_ALGORITHM		 "jwt-algo"
+#define	JWT_KEY			 "jwt-key"
+#define DNS_TXT_URL	         "fabric"
+#define PARODUS_UPSTREAM         "tcp://127.0.0.1:6666"
 
 #define ALLOW_NON_RSA_ALG	false
 
@@ -104,6 +118,11 @@ typedef struct
     char token_acquisition_script[64];
     char token_read_script[64];
     char hub_or_spk[5];
+    /* Instance_type will replace hub_or_spk, so we don't need strcmp, etc...
+       Also will allow for easier addition of any other type   
+    */
+    instance_type_t intstance_type; 
+    int             instance_id; /* i.e. spoke #n */
 } ParodusCfg;
 
 #define FLAGS_IPV6_ONLY (1 << 0)

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -130,27 +130,89 @@ cJSON* __parse_config_file( char *file, int *error )
     return NULL;
 }
 
+
 int __setParodusConfig(cJSON *jsp, ParodusCfg *cfg)
 {
     cJSON *item;
     
     memset(cfg, 0, sizeof(ParodusCfg));
-    
-    /* ToDo: Implement Me ;0) */
-    /* Correct config.h, we should not have hard-coded numbers and limits on strings. */
-    
-    /* Sample implementation of some of the fields ... */
+       
     item = cJSON_GetObjectItem(jsp, HW_MODELNAME);
     if (item && (cJSON_String == item->type)) {
         strncpy(cfg->hw_model, item->valuestring, 64);
     }
+    
+    item = cJSON_GetObjectItem(jsp, HW_SERIALNUMBER);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->hw_serial_number, item->valuestring, 64);
+    }
+ 
+    item = cJSON_GetObjectItem(jsp, HW_MANUFACTURER);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->hw_manufacturer, item->valuestring, 64);
+    }
+    
+    item = cJSON_GetObjectItem(jsp, HW_DEVICEMAC);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->hw_mac, item->valuestring, 64);
+    }
+    
+    item = cJSON_GetObjectItem(jsp, HW_LAST_REBOOT_REASON);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->hw_last_reboot_reason, item->valuestring, 64);
+    }
+                
+    item = cJSON_GetObjectItem(jsp, FIRMWARE_NAME);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->fw_name, item->valuestring, 64);
+    }
+    
+    item = cJSON_GetObjectItem(jsp, BOOT_TIME);
+    if (item && (cJSON_Number == item->type)) {
+        cfg->boot_time = item->valueint;
+    }
+    
+    item = cJSON_GetObjectItem(jsp, WEBPA_PROTOCOL);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->webpa_protocol, item->valuestring, 64);
+    }    
+    
+    item = cJSON_GetObjectItem(jsp, WEBPA_INTERFACE);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->webpa_interface_used, item->valuestring, 64);
+    }
+     
+    item = cJSON_GetObjectItem(jsp, WEBPA_UUID);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->webpa_uuid, item->valuestring, 64);
+    }  
     
     item = cJSON_GetObjectItem(jsp, WEBPA_PING_TIMEOUT);
     if (item && (cJSON_Number == item->type)) {
         cfg->webpa_ping_timeout = item->valueint;
     }
 
+    item = cJSON_GetObjectItem(jsp, WEBPA_URL);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->webpa_url, item->valuestring, 64);
+    }
     
-    // Not completed...so always return an error.
-    return -4;
+    item = cJSON_GetObjectItem(jsp, WEBPA_BACKOFF_MAX);
+    if (item && (cJSON_Number == item->type)) {
+        cfg->webpa_backoff_max = item->valueint;
+    }
+
+    item = cJSON_GetObjectItem(jsp, PARTNER_ID);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->partner_id, item->valuestring, 64);
+    }
+     
+     item = cJSON_GetObjectItem(jsp, CERT_PATH);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->cert_path, item->valuestring, 64);
+    }
+ 
+    /* ToDo: Do a check of required fields */ 
+     
+    return 0;
 }

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/**
+ * @file config_file.c
+ *
+ * @description This file contains configuration file parsing for parodus
+ *
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <cJSON.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "config.h"
+#include "config_file.h"
+#include "ParodusInternal.h"
+#include "parodus_log.h"
+
+
+
+/* Exported Functions */
+int processParodusCfg(ParodusCfg *cfg, char *config_disk_file);
+
+
+/* Internal Functions */
+static cJSON* __parse_config_file( char *file, int *error );
+int __setParodusConfig(cJSON *jsp, ParodusCfg *cfg);
+
+
+/* Local static variables */
+
+
+
+int processParodusCfg(ParodusCfg *cfg, char *file)
+{
+    cJSON *jsp = NULL;
+    int error = 0;
+    
+    (void ) cfg;
+    
+    jsp = __parse_config_file(file, &error);
+    
+    if (error) {
+      ParodusError("processParodusCfg(cfg, %s): Failed %d\n", file, error);  
+      if (jsp) {
+        cJSON_Delete(jsp);
+      }  
+      return error;
+    } 
+    
+    error = __setParodusConfig(jsp, cfg);
+    
+    cJSON_Delete(jsp);
+
+    return error;
+}
+
+
+cJSON* __parse_config_file( char *file, int *error )
+{
+    FILE *fp;
+    char *text;
+    static cJSON_Hooks hooks = { .malloc_fn = malloc,
+                                 .free_fn = free };
+    cJSON_InitHooks( &hooks );
+
+    text = NULL;
+    fp = fopen( file, "r" );
+    if( NULL != fp ) {
+        if( 0 == fseek(fp, 0, SEEK_END) ) {
+            size_t size;
+            
+            size = ftell( fp );
+            if( 0 < size ) {
+                rewind( fp );
+
+                text = (char*) malloc( sizeof(char) * (size + 1) );
+                if( NULL != text ) {
+                    if( size != fread(text, sizeof(char), size, fp) ) {
+                        free( text );
+                        text = NULL;
+                    } else {
+                        text[size] = '\0';
+                    }
+                }
+            }
+        }
+        fclose( fp );
+    } else {
+        ParodusError("\n__parse_config_file():Can't open file %s\n", file);
+        *error = -1;
+        return NULL;
+    }
+
+    if( NULL != text ) {
+        cJSON *rv;
+        
+        rv = cJSON_Parse(text);
+        free(text);
+        if (NULL == rv) {
+            *error = -2;
+        } else {
+            *error = 0;
+        }
+        return rv;
+    } else {
+        *error = -3;
+        ParodusError("__parse_config_file():malloc failed\n");
+    }
+
+    return NULL;
+}
+
+int __setParodusConfig(cJSON *jsp, ParodusCfg *cfg)
+{
+    cJSON *item;
+    
+    memset(cfg, 0, sizeof(ParodusCfg));
+    
+    /* ToDo: Implement Me ;0) */
+    /* Correct config.h, we should not have hard-coded numbers and limits on strings. */
+    
+    /* Sample implementation of some of the fields ... */
+    item = cJSON_GetObjectItem(jsp, HW_MODELNAME);
+    if (item && (cJSON_String == item->type)) {
+        strncpy(cfg->hw_model, item->valuestring, 64);
+    }
+    
+    item = cJSON_GetObjectItem(jsp, WEBPA_PING_TIMEOUT);
+    if (item && (cJSON_Number == item->type)) {
+        cfg->webpa_ping_timeout = item->valueint;
+    }
+
+    
+    // Not completed...so always return an error.
+    return -4;
+}

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CONFIG_FILE_H__
+#define __CONFIG_FILE_H__
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*
+ Parses json config_disk_file and fills cfg, 
+ returns 0 on success
+ a negative number on errors.
+ */
+int processParodusCfg(ParodusCfg *cfg, char *config_disk_file);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,8 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -g3 -fprofile-arcs -ftest-coverage
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DTEST ")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W  -g3 -fprofile-arcs -ftest-coverage -O0")
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -O0")
-set (PARODUS_COMMON_SRC ../src/string_helpers.c ../src/mutex.c ../src/time.c ../src/config.c ../src/spin_thread.c ../src/token.c)
+set (PARODUS_COMMON_SRC ../src/string_helpers.c ../src/mutex.c ../src/time.c
+     ../src/config.c ../src/spin_thread.c ../src/token.c ../src/config_file.c )
 set (PARODUS_COMMON_LIBS gcov -lcunit -lcimplog -lwrp-c
  -luuid -lpthread -lmsgpackc -lnopoll -lnanomsg
  -Wl,--no-as-needed -lcjson -lcjwt -ltrower-base64
@@ -137,7 +138,8 @@ target_link_libraries (test_connection ${PARODUS_COMMON_LIBS} -lcmocka)
 add_test(NAME test_createConnection COMMAND ${MEMORY_CHECK} ./test_createConnection)
 #add_executable(test_createConnection test_createConnection.c ../src/connection.c ../src/string_helpers.c ../src/config.c) 
 #target_link_libraries (test_createConnection ${PARODUS_COMMON_LIBS} -lcmocka)
-add_executable(test_createConnection test_createConnection.c ../src/connection.c ../src/string_helpers.c ../src/config.c) 
+add_executable(test_createConnection test_createConnection.c ../src/connection.c
+               ../src/string_helpers.c ../src/config.c ../src/config_file.c ) 
 #target_link_libraries (test_createConnection ${PARODUS_CONN_LIBS} ${PARODUS_COMMON_LIBS} -lcmocka )
 target_link_libraries (test_createConnection ${PARODUS_COMMON_LIBS} -lcmocka )
 
@@ -169,7 +171,12 @@ target_link_libraries (test_client_list ${PARODUS_COMMON_LIBS})
 add_test(NAME test_service_alive COMMAND ${MEMORY_CHECK} ./test_service_alive)
 #add_executable(test_service_alive test_service_alive.c ../src/client_list.c ../src/service_alive.c ../src/upstream.c ../src/networking.c ../src/nopoll_helpers.c ../src/nopoll_handlers.c ../src/config.c ../src/connection.c ../src/ParodusInternal.c ../src/downstream.c ../src/thread_tasks.c ../src/conn_interface.c ../src/partners_check.c ${PARODUS_COMMON_SRC})
 #target_link_libraries (test_service_alive ${PARODUS_COMMON_LIBS})
-set(SVA_SRC test_service_alive.c ../src/client_list.c ../src/service_alive.c ../src/upstream.c ../src/networking.c ../src/nopoll_helpers.c ../src/nopoll_handlers.c ../src/config.c ../src/connection.c ../src/ParodusInternal.c ../src/downstream.c ../src/thread_tasks.c ../src/conn_interface.c ../src/partners_check.c ../src/parodus_interface.c ../src/peer2peer.c ${PARODUS_COMMON_SRC})
+set(SVA_SRC test_service_alive.c ../src/client_list.c ../src/service_alive.c
+    ../src/upstream.c ../src/networking.c ../src/nopoll_helpers.c 
+    ../src/nopoll_handlers.c ../src/config.c ../src/config_file.c ../src/connection.c
+    ../src/ParodusInternal.c ../src/downstream.c ../src/thread_tasks.c
+    ../src/conn_interface.c ../src/partners_check.c ../src/parodus_interface.c
+    ../src/peer2peer.c ${PARODUS_COMMON_SRC})
 if (ENABLE_SESHAT)
 set(SVA_SRC ${SVA_SRC} ../src/seshat_interface.c)
 else()
@@ -217,7 +224,8 @@ target_link_libraries ( producer
 #   test_config
 #-------------------------------------------------------------------------------
 add_test(NAME test_config COMMAND ${MEMORY_CHECK} ./test_config)
-add_executable(test_config test_config.c ../src/config.c ../src/string_helpers.c)
+add_executable(test_config test_config.c ../src/config.c ../src/config_file.c
+               ../src/string_helpers.c)
 target_link_libraries (test_config -lcmocka
  -Wl,--no-as-needed -lcimplog
  -lcjson -lcjwt -ltrower-base64 -lssl -lcrypto -lrt -lm
@@ -259,6 +267,7 @@ add_test(NAME test_conn_interface COMMAND ${MEMORY_CHECK} ./test_conn_interface)
 set(CONIFC_SRC test_conn_interface.c 
   ../src/conn_interface.c 
   ../src/config.c 
+  ../src/config_file.c
   ../src/token.c
   ../src/string_helpers.c 
   ../src/mutex.c
@@ -277,7 +286,10 @@ target_link_libraries (test_conn_interface -lcmocka ${PARODUS_COMMON_LIBS} )
 #   test_ParodusInternal
 #-------------------------------------------------------------------------------
 add_test(NAME test_ParodusInternal COMMAND ${MEMORY_CHECK} ./test_ParodusInternal)
-add_executable(test_ParodusInternal test_ParodusInternal.c ../src/ParodusInternal.c ../src/config.c ../src/string_helpers.c)
+add_executable(test_ParodusInternal test_ParodusInternal.c 
+               ../src/ParodusInternal.c 
+               ../src/config.c ../src/config_file.c
+               ../src/string_helpers.c)
 target_link_libraries (test_ParodusInternal -lcmocka ${PARODUS_COMMON_LIBS} )
 
 #-------------------------------------------------------------------------------
@@ -291,7 +303,7 @@ target_link_libraries (test_partners_check -lcmocka ${PARODUS_COMMON_LIBS} -lwrp
 #   test_token - token.c tests
 #-------------------------------------------------------------------------------
 add_test(NAME test_token COMMAND ${MEMORY_CHECK} ./test_token)
-set(TOKEN_SRC ../src/conn_interface.c ../src/config.c
+set(TOKEN_SRC ../src/conn_interface.c ../src/config.c ../src/config_file.c
  ../src/connection.c ../src/spin_thread.c
  ../src/service_alive.c ../src/client_list.c
  ../src/nopoll_handlers.c ../src/nopoll_helpers.c
@@ -351,8 +363,13 @@ target_link_libraries (simple_connection ${PARODUS_CONN_LIBS} ${PARODUS_COMMON_L
 #   simple test
 #-------------------------------------------------------------------------------
 add_test(NAME simple COMMAND ${MEMORY_CHECK} ./simple)
-set(SIMPLE_SRC simple.c ../src/upstream.c ../src/conn_interface.c ../src/downstream.c ../src/thread_tasks.c ../src/networking.c ../src/nopoll_helpers.c ../src/nopoll_handlers.c ../src/string_helpers.c ../src/mutex.c ../src/time.c
- ../src/config.c ../src/connection.c ../src/ParodusInternal.c ../src/spin_thread.c ../src/client_list.c ../src/partners_check.c ../src/service_alive.c)
+set(SIMPLE_SRC simple.c ../src/upstream.c ../src/conn_interface.c
+ ../src/downstream.c ../src/thread_tasks.c ../src/networking.c 
+ ../src/nopoll_helpers.c ../src/nopoll_handlers.c ../src/string_helpers.c
+ ../src/mutex.c ../src/time.c ../src/config.c ./src/config_file.c 
+ ../src/connection.c ../src/ParodusInternal.c ../src/spin_thread.c
+ ../src/client_list.c ../src/partners_check.c ../src/service_alive.c)
+
 if (ENABLE_SESHAT)
 set(SIMPLE_SRC ${SIMPLE_SRC} ../src/seshat_interface.c)
 else()

--- a/tests/config_file.json
+++ b/tests/config_file.json
@@ -1,0 +1,19 @@
+{
+"hw-model": "TGXXX",
+"hw-serial-number": "E8GBUEXXXXXXXXX",
+"hw-manufacturer": "ARRIS",
+"hw-mac": "888888888888",
+"hw-last-reboot-reason": "unknown",
+"fw-name": "TG1682_DEV_master_20170512115046sdy",
+"boot-time": "1494590301",
+"webpa-ping-timeout": 180,
+"webpa-interface-used": "wlp0s20u2",
+"webpa-backoff-max": 9,
+"parodus-local-url": "tcp://127.0.0.1:8888",
+"partner-id": "comcast",
+"ssl-cert-path": "/etc/ssl/certs/ca-bundle.crt",
+"webpa-url": "https://fabric.webpa.comcast.net:8080",
+"force-ipv4": "true",
+"instance-type": 1,
+"life-time": 300
+}

--- a/tests/producer.c
+++ b/tests/producer.c
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #include <cimplog/cimplog.h>
 #include <cJSON.h>
+#include <time.h>
 
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
@@ -259,6 +260,10 @@ static int main_loop(libpd_cfg_t *cfg)
     int c = 2;
     char source[128];
     char destination[128];
+    char *contentType;
+    cJSON *response;
+    cJSON *parameters;
+    cJSON *device_id, *time_stamp;
 
     while( true ) {
         rv = libparodus_init( &hpd, cfg );
@@ -284,15 +289,44 @@ static int main_loop(libpd_cfg_t *cfg)
     snprintf(source,127,"mac:/%s/%s", mac_address, SERVICE_NAME);
     snprintf(destination, 127, "event:node-change/");
     // zztop snprintf(destination, 127, "event:node-change/%s","printer");
+    
+    contentType = (char *) malloc(sizeof(char) * (strlen(CONTENT_TYPE_JSON) + 1));
+	if (contentType) {
+        strncpy(contentType, CONTENT_TYPE_JSON, strlen(CONTENT_TYPE_JSON) + 1);
+    } else {
+        printf("Hell Froze over! Malloc failed!\n");
+        exit (-911);
+    } 
+    
     printf("starting the main loop...\n");
     do {
+        struct timespec tm;
+        time_t unix_time = 0;
+        char *str;
+        char time_str[32] = "0";
+        
+        if( 0 == clock_gettime(CLOCK_REALTIME, &tm) ) {
+            unix_time = tm.tv_sec; // ignore tm.tv_nsec
+            snprintf(time_str, 32, "%lu", unix_time);
+        }    
+            
+        response = cJSON_CreateObject();
+        cJSON_AddItemToObject(response, "parameters", parameters =cJSON_CreateArray());
+        cJSON_AddItemToArray(parameters, device_id = cJSON_CreateObject());
+        cJSON_AddStringToObject(device_id, "device_id", mac_address);
+        cJSON_AddItemToArray(parameters, time_stamp = cJSON_CreateObject());
+        cJSON_AddStringToObject(device_id, "timestamp", time_str);          
+        str = cJSON_PrintUnformatted(response);
+        printf("Payload Response: %s\n", str);
+
         memset(&wrp_msg, 0, sizeof(wrp_msg_t));
         wrp_msg.msg_type = WRP_MSG_TYPE__EVENT;     
 
 	    wrp_msg.u.event.source = strdup(source);
         wrp_msg.u.event.dest   = strdup(destination);
-	    wrp_msg.u.event.payload = NULL;
-        wrp_msg.u.event.payload_size = 0;
+        wrp_msg.u.event.content_type = strdup(contentType);
+	    wrp_msg.u.event.payload = str;
+        wrp_msg.u.event.payload_size = strlen(str);
         
         
         rv = libparodus_send(hpd, &wrp_msg);

--- a/tests/producer.c
+++ b/tests/producer.c
@@ -265,6 +265,8 @@ static int main_loop(libpd_cfg_t *cfg)
     cJSON *parameters;
     cJSON *device_id, *time_stamp;
 
+    (void ) device_id; (void ) parameters; (void ) time_stamp;
+
     while( true ) {
         rv = libparodus_init( &hpd, cfg );
         if( 0 != rv ) {
@@ -311,11 +313,14 @@ static int main_loop(libpd_cfg_t *cfg)
         }    
             
         response = cJSON_CreateObject();
-        cJSON_AddItemToObject(response, "parameters", parameters =cJSON_CreateArray());
-        cJSON_AddItemToArray(parameters, device_id = cJSON_CreateObject());
-        cJSON_AddStringToObject(device_id, "device_id", mac_address);
-        cJSON_AddItemToArray(parameters, time_stamp = cJSON_CreateObject());
-        cJSON_AddStringToObject(device_id, "timestamp", time_str);          
+        //cJSON_AddItemToObject(response, "parameters", parameters =cJSON_CreateArray());
+        //cJSON_AddItemToArray(parameters, device_id = cJSON_CreateObject());
+        //cJSON_AddStringToObject(device_id, "device_id", mac_address);
+	cJSON_AddStringToObject(response, "device_id", mac_address);
+
+        //cJSON_AddItemToArray(parameters, time_stamp = cJSON_CreateObject());
+        //cJSON_AddStringToObject(device_id, "timestamp", time_str);
+	cJSON_AddStringToObject(response, "timestamp", time_str);
         str = cJSON_PrintUnformatted(response);
         printf("Payload Response: %s\n", str);
 


### PR DESCRIPTION
… the code in __setParodusConfig() done but needs to be completed. Adding a -F command line option which passes in the json cofiguration file name. Specifying -F currently will overwrite any other command line param

ToDo: Complete __setParodusConfig()
Optimize (?) config.h so all CRUD macros can be in an indexable array.
Use a defined type (enum) for hub-or-spoke
